### PR TITLE
Extends functionality of math operations

### DIFF
--- a/CommunityBot.NUnit.Tests/CommunityBot.NUnit.Tests.csproj
+++ b/CommunityBot.NUnit.Tests/CommunityBot.NUnit.Tests.csproj
@@ -4,13 +4,14 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.10.1"/>
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2"/>
-    <PackageReference Include="coverlet.msbuild" Version="*"/>
-    <PackageReference Include="Moq" Version="*"/>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="nunit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="coverlet.msbuild" Version="*" />
+    <PackageReference Include="Moq" Version="*" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CommunityBot\CommunityBot.csproj"/>
+    <ProjectReference Include="..\CommunityBot\CommunityBot.csproj" />
   </ItemGroup>
 </Project>

--- a/CommunityBot.NUnit.Tests/OperationsTests.cs
+++ b/CommunityBot.NUnit.Tests/OperationsTests.cs
@@ -9,7 +9,7 @@ namespace CommunityBot.NUnit.Tests
     class OperationsTests
     {
         [Test]
-        public void OperationsMultBeforAdd()
+        public static void OperationsMultBeforAdd()
         {
             double expected = 10 + 5 * 2;
 
@@ -19,7 +19,7 @@ namespace CommunityBot.NUnit.Tests
         }
 
         [Test]
-        public void OperationsWrongInput_Returns0()
+        public static void OperationsWrongInput_Returns0()
         {
             double expected = 0;
 
@@ -29,7 +29,7 @@ namespace CommunityBot.NUnit.Tests
         }
 
         [Test]
-        public void OperationsMultipleOperationsAttached()
+        public static void OperationsMultipleOperationsAttached()
         {
             double expected = 0;
 
@@ -39,7 +39,7 @@ namespace CommunityBot.NUnit.Tests
         }
 
         [Test]
-        public void OperationsInputTooShort_Returns0()
+        public static void OperationsInputTooShort_Returns0()
         {
             double expected = 0;
 
@@ -49,7 +49,7 @@ namespace CommunityBot.NUnit.Tests
         }
 
         [Test]
-        public void OperationsInputLeadingOperationAddSub()
+        public static void OperationsInputLeadingOperationAddSub()
         {
             double expected = -4+5;
 
@@ -59,7 +59,7 @@ namespace CommunityBot.NUnit.Tests
         }
 
         [Test]
-        public void OperationsInputLeadingOperationMultDiv()
+        public static void OperationsInputLeadingOperationMultDiv()
         {
             double expected = 0 + 5;
 

--- a/CommunityBot.NUnit.Tests/OperationsTests.cs
+++ b/CommunityBot.NUnit.Tests/OperationsTests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+using CommunityBot.Helpers;
+
+namespace CommunityBot.NUnit.Tests
+{
+    class OperationsTests
+    {
+        [Test]
+        public void OperationsMultBeforAdd()
+        {
+            double expected = 10 + 5 * 2;
+
+            double actual = Operations.PerformComputation("10+5*2");
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void OperationsWrongInput_Returns0()
+        {
+            double expected = 0;
+
+            double actual = Operations.PerformComputation("1+x");
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void OperationsMultipleOperationsAttached()
+        {
+            double expected = 0;
+
+            double actual = Operations.PerformComputation("1++");
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void OperationsInputTooShort_Returns0()
+        {
+            double expected = 0;
+
+            double actual = Operations.PerformComputation("-3");
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void OperationsInputLeadingOperationAddSub()
+        {
+            double expected = -4+5;
+
+            double actual = Operations.PerformComputation("-4+5");
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void OperationsInputLeadingOperationMultDiv()
+        {
+            double expected = 0 + 5;
+
+            double actual = Operations.PerformComputation("*3+5");
+
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/CommunityBot.NUnit.Tests/OperationsTests.cs
+++ b/CommunityBot.NUnit.Tests/OperationsTests.cs
@@ -6,7 +6,7 @@ using CommunityBot.Helpers;
 
 namespace CommunityBot.NUnit.Tests
 {
-    class OperationsTests
+    public static class OperationsTests
     {
         [Test]
         public static void OperationsMultBeforAdd()

--- a/CommunityBot/CommunityBot.csproj
+++ b/CommunityBot/CommunityBot.csproj
@@ -14,8 +14,9 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="2.0.0-beta2-00970"/>
-    <PackageReference Include="Ofl.Google.Maps" Version="3.0.22"/>
-    <PackageReference Include="Lamar" Version="*"/>
+    <PackageReference Include="Discord.Net" Version="2.0.0-beta2-00970" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Ofl.Google.Maps" Version="3.0.22" />
+    <PackageReference Include="Lamar" Version="*" />
   </ItemGroup>
 </Project>

--- a/CommunityBot/Helpers/Operations.cs
+++ b/CommunityBot/Helpers/Operations.cs
@@ -18,7 +18,7 @@ namespace CommunityBot.Helpers
 
         public static double PerformComputation(String sentence)
         {
-            if (!string.IsNullOrEmpty(sentence) || sentence.Length < 3) return 0;
+            if (string.IsNullOrEmpty(sentence) || sentence.Length < 3) { return 0; }
 
             var seperatedValues = new List<string>();
             SeperateValues(seperatedValues, sentence);
@@ -44,8 +44,16 @@ namespace CommunityBot.Helpers
                     ReplaceSegment(seperatedValues, 0);
                 }
             }
-            double x = double.Parse(seperatedValues[0]);
-            double y = double.Parse(seperatedValues[2]);
+            double x, y;
+            try
+            {
+                x = double.Parse(seperatedValues[0]);
+                y = double.Parse(seperatedValues[2]);
+            }
+            catch (FormatException e)
+            {
+                return 0;
+            }
             return validOperations[seperatedValues[1]](x, y);
         }
 
@@ -56,6 +64,7 @@ namespace CommunityBot.Helpers
             {
                 if (validOperations.ContainsKey(sentence[i].ToString()))
                 {
+                    if (i==0) { buffer.Append("0"); }
                     list.Add(buffer.ToString());
                     list.Add(sentence[i].ToString());
                     buffer = new StringBuilder();

--- a/CommunityBot/Helpers/Operations.cs
+++ b/CommunityBot/Helpers/Operations.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Globalization;
 
 namespace CommunityBot.Helpers
 {
@@ -79,14 +80,14 @@ namespace CommunityBot.Helpers
 
         private static void ReplaceSegment(List<String> list, int startIdx)
         {
-            if (list.Count < 3) return;
+            if (list.Count < 3) { return; }
             String s = "";
             s += list[startIdx+0];
             s += list[startIdx+1];
             s += list[startIdx+2];
             list.RemoveAt(startIdx);
             list.RemoveAt(startIdx);
-            list[startIdx] = Operations.PerformComputation(s).ToString();
+            list[startIdx] = Operations.PerformComputation(s).ToString(CultureInfo.CurrentCulture);
         }
 
         private static double Add(double x, double y)

--- a/CommunityBot/Helpers/Operations.cs
+++ b/CommunityBot/Helpers/Operations.cs
@@ -18,11 +18,13 @@ namespace CommunityBot.Helpers
 
         public static double PerformComputation(String sentence)
         {
-            if (sentence == null || sentence.Length == 0 || sentence.Length < 3) return 0;
+            if (!string.IsNullOrEmpty(sentence) || sentence.Length < 3) return 0;
 
-            List<String> seperatedValues = new List<string>();
+            var seperatedValues = new List<string>();
             SeperateValues(seperatedValues, sentence);
 
+            // Initial check, because multiplication and division have a higher priority 
+            // than addition and subtraction. 
             if (seperatedValues.Count > 3)
             {
                 int i = 0;

--- a/CommunityBot/Helpers/Operations.cs
+++ b/CommunityBot/Helpers/Operations.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CommunityBot.Helpers
+{
+    public static class Operations
+    {
+
+        public static Dictionary<String, Func<double, double, double>> validOperations = new Dictionary<String, Func<double, double, double>>()
+        {
+            { "+", Add },
+            { "-", Sub },
+            { "*", Mult },
+            { "/", Div },
+            { "%", Mod }
+        };
+
+        public static double PerformComputation(String sentence)
+        {
+            if (sentence == null || sentence.Length == 0 || sentence.Length < 3) return 0;
+
+            List<String> seperatedValues = new List<string>();
+            String buffer = "";
+            for (int i=0; i<sentence.Length; i++)
+            {
+                if (validOperations.ContainsKey(sentence[i].ToString()))
+                {
+                    seperatedValues.Add(buffer);
+                    seperatedValues.Add(sentence[i].ToString());
+                    buffer = "";
+                }
+                else
+                {
+                    buffer += sentence[i];
+                }
+            }
+            seperatedValues.Add(buffer);
+
+            if (seperatedValues.Count > 3)
+            {
+                int pos = 0;
+                while (seperatedValues.Contains("*") || seperatedValues.Contains("/"))
+                {
+                    for (int i = pos; i < seperatedValues.Count; i++)
+                    {
+                        if (seperatedValues[i].Equals("*") || seperatedValues[i].Equals("/"))
+                        {
+                            String s = "";
+                            s += seperatedValues[i - 1];
+                            s += seperatedValues[i + 0];
+                            s += seperatedValues[i + 1];
+                            seperatedValues.RemoveAt(i - 1);
+                            seperatedValues.RemoveAt(i - 1);
+                            seperatedValues[i - 1] = ((double)Operations.PerformComputation(s)).ToString();
+                            break;
+                        }
+                        pos++;
+                    }
+                }
+                while (seperatedValues.Count > 3)
+                {
+                    String s = "";
+                    s += seperatedValues[0];
+                    s += seperatedValues[1];
+                    s += seperatedValues[2];
+                    seperatedValues.RemoveAt(0);
+                    seperatedValues.RemoveAt(0);
+                    seperatedValues[0] = ((double)Operations.PerformComputation(s)).ToString();
+                }
+            }
+            double x = double.Parse(seperatedValues[0]);
+            double y = double.Parse(seperatedValues[2]);
+            return validOperations[seperatedValues[1]](x, y);
+        }
+
+        private static double Add(double x, double y)
+        {
+            return x + y;
+        }
+
+        private static double Sub(double x, double y)
+        {
+            return x - y;
+        }
+
+        private static double Mult(double x, double y)
+        {
+            return x * y;
+        }
+
+        private static double Div(double x, double y)
+        {
+            return x / y;
+        }
+
+        private static double Mod(double x, double y)
+        {
+            return x % y;
+        }
+    }
+}

--- a/CommunityBot/Helpers/Operations.cs
+++ b/CommunityBot/Helpers/Operations.cs
@@ -7,7 +7,7 @@ namespace CommunityBot.Helpers
     public static class Operations
     {
 
-        public static Dictionary<String, Func<double, double, double>> validOperations = new Dictionary<String, Func<double, double, double>>()
+        private static Dictionary<String, Func<double, double, double>> validOperations = new Dictionary<String, Func<double, double, double>>
         {
             { "+", Add },
             { "-", Sub },
@@ -21,57 +21,61 @@ namespace CommunityBot.Helpers
             if (sentence == null || sentence.Length == 0 || sentence.Length < 3) return 0;
 
             List<String> seperatedValues = new List<string>();
-            String buffer = "";
-            for (int i=0; i<sentence.Length; i++)
-            {
-                if (validOperations.ContainsKey(sentence[i].ToString()))
-                {
-                    seperatedValues.Add(buffer);
-                    seperatedValues.Add(sentence[i].ToString());
-                    buffer = "";
-                }
-                else
-                {
-                    buffer += sentence[i];
-                }
-            }
-            seperatedValues.Add(buffer);
+            SeperateValues(seperatedValues, sentence);
 
             if (seperatedValues.Count > 3)
             {
-                int pos = 0;
-                while (seperatedValues.Contains("*") || seperatedValues.Contains("/"))
+                int i = 0;
+                while (i < seperatedValues.Count-1)
                 {
-                    for (int i = pos; i < seperatedValues.Count; i++)
+                    if (seperatedValues[i + 1].Equals("*") || seperatedValues[i + 1].Equals("/"))
                     {
-                        if (seperatedValues[i].Equals("*") || seperatedValues[i].Equals("/"))
-                        {
-                            String s = "";
-                            s += seperatedValues[i - 1];
-                            s += seperatedValues[i + 0];
-                            s += seperatedValues[i + 1];
-                            seperatedValues.RemoveAt(i - 1);
-                            seperatedValues.RemoveAt(i - 1);
-                            seperatedValues[i - 1] = ((double)Operations.PerformComputation(s)).ToString();
-                            break;
-                        }
-                        pos++;
+                        ReplaceSegment(seperatedValues, i);
+                    }
+                    else
+                    {
+                        i++;
                     }
                 }
                 while (seperatedValues.Count > 3)
                 {
-                    String s = "";
-                    s += seperatedValues[0];
-                    s += seperatedValues[1];
-                    s += seperatedValues[2];
-                    seperatedValues.RemoveAt(0);
-                    seperatedValues.RemoveAt(0);
-                    seperatedValues[0] = ((double)Operations.PerformComputation(s)).ToString();
+                    ReplaceSegment(seperatedValues, 0);
                 }
             }
             double x = double.Parse(seperatedValues[0]);
             double y = double.Parse(seperatedValues[2]);
             return validOperations[seperatedValues[1]](x, y);
+        }
+
+        private static void SeperateValues(List<String> list, String sentence)
+        {
+            StringBuilder buffer = new StringBuilder();
+            for (int i = 0; i < sentence.Length; i++)
+            {
+                if (validOperations.ContainsKey(sentence[i].ToString()))
+                {
+                    list.Add(buffer.ToString());
+                    list.Add(sentence[i].ToString());
+                    buffer = new StringBuilder();
+                }
+                else
+                {
+                    buffer.Append(sentence[i]);
+                }
+            }
+            list.Add(buffer.ToString());
+        }
+
+        private static void ReplaceSegment(List<String> list, int startIdx)
+        {
+            if (list.Count < 3) return;
+            String s = "";
+            s += list[startIdx+0];
+            s += list[startIdx+1];
+            s += list[startIdx+2];
+            list.RemoveAt(startIdx);
+            list.RemoveAt(startIdx);
+            list[startIdx] = Operations.PerformComputation(s).ToString();
         }
 
         private static double Add(double x, double y)

--- a/CommunityBot/Modules/Misc.cs
+++ b/CommunityBot/Modules/Misc.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Text;
 using CommunityBot.Helpers;
 
 namespace CommunityBot.Modules
@@ -245,17 +246,17 @@ namespace CommunityBot.Modules
         [Summary("Computates mathematical operations.")]
         public async Task Computate(params String[] input)
         {
-            String word = "";
+            StringBuilder word = new StringBuilder();
             for (int i = 0; i < input.Length; i++)
             {
                 char[] inputWithoutSpaces = input.ElementAt(i).Where(c => !Char.IsWhiteSpace(c)).ToArray();
                 for (int j = 0; j < inputWithoutSpaces.Count(); j++)
                 {
-                    word += inputWithoutSpaces[j];
+                    word.Append(inputWithoutSpaces[j]);
                 }
 
-                input[i] = word;
-                word = "";
+                input[i] = word.ToString();
+                word = new StringBuilder();
                 if (input.ElementAt(i).Length > 2)
                 {
                     input[i] = ((double)Operations.PerformComputation(input[i])).ToString();

--- a/CommunityBot/Modules/Misc.cs
+++ b/CommunityBot/Modules/Misc.cs
@@ -243,7 +243,7 @@ namespace CommunityBot.Modules
         }
 
         [Command("Math")]
-        [Summary("Computates mathematical operations.")]
+        [Summary("Computes mathematical operations.")]
         public async Task Computate(params String[] input)
         {
             StringBuilder word = new StringBuilder();

--- a/CommunityBot/Modules/Misc.cs
+++ b/CommunityBot/Modules/Misc.cs
@@ -142,11 +142,11 @@ namespace CommunityBot.Modules
             }
 
             if (descriptionBuilder.Count <= 0) return;
-            var builtString = string.Join("\n", descriptionBuilder); 
+            var builtString = string.Join("\n", descriptionBuilder);
             var testLength = builtString.Length;
             if (testLength >= 1024)
             {
-                throw  new ArgumentException("Value cannot exceed 1024 characters");
+                throw new ArgumentException("Value cannot exceed 1024 characters");
             }
             var moduleNotes = "";
             if (!string.IsNullOrEmpty(module.Summary))
@@ -190,36 +190,36 @@ namespace CommunityBot.Modules
                 );
                 return emb.AddField(GitHub.ContributionStat(cont, stats));
             });
-            
+
             await ReplyAsync("", false, embB.Build());
         }
 
-	    [Command("bug")]
-	    [Alias("bug-report","issue","feedback")]
-	    [Summary("It sends users where to report bugs.")]
-	    public async Task Bug()
-	    {
-			var embed = new EmbedBuilder();
-		    embed.WithColor(99, 193, 50);
-		    embed.WithTitle("Bug reporting");
-		    embed.WithDescription(@"Thank you for your interest, how about you let us know by creating an Issue on our **GitHub** "+ "\n\n\n" +
-			"**[ 🢂 🐞 HERE 🐞 🢀 ](https://github.com/discord-bot-tutorial/Community-Discord-BOT/issues/new/choose)**" + "\n\n\n" +
-		    "(*If button doesnt work: https://github.com/discord-bot-tutorial/Community-Discord-BOT/issues/new/choose*)");
-		    embed.WithFooter("Your help is more than welcome!");
-		    embed.WithAuthor(Global.Client.CurrentUser);
-		    embed.WithCurrentTimestamp();
+        [Command("bug")]
+        [Alias("bug-report", "issue", "feedback")]
+        [Summary("It sends users where to report bugs.")]
+        public async Task Bug()
+        {
+            var embed = new EmbedBuilder();
+            embed.WithColor(99, 193, 50);
+            embed.WithTitle("Bug reporting");
+            embed.WithDescription(@"Thank you for your interest, how about you let us know by creating an Issue on our **GitHub** " + "\n\n\n" +
+            "**[ 🢂 🐞 HERE 🐞 🢀 ](https://github.com/discord-bot-tutorial/Community-Discord-BOT/issues/new/choose)**" + "\n\n\n" +
+            "(*If button doesnt work: https://github.com/discord-bot-tutorial/Community-Discord-BOT/issues/new/choose*)");
+            embed.WithFooter("Your help is more than welcome!");
+            embed.WithAuthor(Global.Client.CurrentUser);
+            embed.WithCurrentTimestamp();
 
-			await ReplyAsync("",false,embed.Build());
+            await ReplyAsync("", false, embed.Build());
 
-		}
+        }
 
-		[Command("Addition")]
+        [Command("Addition")]
         [Summary("Adds 2 numbers together.")]
         public async Task AddAsync(float num1, float num2)
         {
             await ReplyAsync($"The Answer To That Is: {num1 + num2}");
         }
-        
+
         [Command("Subtract")]
         [Summary("Subtracts 2 numbers.")]
         public async Task SubstractAsync(float num1, float num2)
@@ -239,6 +239,35 @@ namespace CommunityBot.Modules
         public async Task DivideAsync(float num1, float num2)
         {
             await ReplyAsync($"The Answer To That Is: {num1 / num2}");
+        }
+
+        [Command("Math")]
+        [Summary("Computates mathematical operations.")]
+        public async Task Computate(params String[] input)
+        {
+            String word = "";
+            for (int i = 0; i < input.Length; i++)
+            {
+                char[] inputWithoutSpaces = input.ElementAt(i).Where(c => !Char.IsWhiteSpace(c)).ToArray();
+                for (int j = 0; j < inputWithoutSpaces.Count(); j++)
+                {
+                    word += inputWithoutSpaces[j];
+                }
+
+                input[i] = word;
+                word = "";
+                if (input.ElementAt(i).Length > 2)
+                {
+                    input[i] = ((double)Operations.PerformComputation(input[i])).ToString();
+                }
+            }
+            String sentence = "";
+            for (int i=0; i<input.Length; i++)
+            {
+                sentence += input[i];
+            }
+            
+            await ReplyAsync($"{Operations.PerformComputation(sentence)}");
         }
     }
 }

--- a/CommunityBot/Modules/Misc.cs
+++ b/CommunityBot/Modules/Misc.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Text;
 using CommunityBot.Helpers;
+using System.Globalization;
 
 namespace CommunityBot.Modules
 {
@@ -259,16 +260,16 @@ namespace CommunityBot.Modules
                 word = new StringBuilder();
                 if (input.ElementAt(i).Length > 2)
                 {
-                    input[i] = ((double)Operations.PerformComputation(input[i])).ToString();
+                    input[i] = Operations.PerformComputation(input[i]).ToString(CultureInfo.CurrentCulture);
                 }
             }
-            String sentence = "";
+            StringBuilder sentence = new StringBuilder();
             for (int i=0; i<input.Length; i++)
             {
-                sentence += input[i];
+                sentence.Append(input[i]);
             }
             
-            await ReplyAsync($"{Operations.PerformComputation(sentence)}");
+            await ReplyAsync($"{Operations.PerformComputation(sentence.ToString())}");
         }
     }
 }


### PR DESCRIPTION
## Related issue
Counting commands #105

## Changes
Added the option to access mathematical operations directly by their symbol (+, -, *, /, %), which also allows brackets to be set

## Expected feedback
I haven't really tested it yet for wrong input cases, so I just want to know, if the code is written in an acceptable manner and if you want the concept to be extended to sqrt or pow for example.