### PR TITLE
MiunieCommandContext implementation, fixed some bugs

### DIFF
--- a/CommunityBot/Entities/GlobalUserAccount.cs
+++ b/CommunityBot/Entities/GlobalUserAccount.cs
@@ -25,10 +25,7 @@ namespace CommunityBot.Entities
 
         private List<CommandInformation> _commandHistory { get; } = new List<CommandInformation>();
 
-        public ReadOnlyCollection<CommandInformation> GetCommandHistory()
-        {
-            return _commandHistory.AsReadOnly();
-        }
+        public ReadOnlyCollection<CommandInformation> CommandHistory;
 
         public void AddCommandToHistory(CommandInformation commandInformation)
         {
@@ -37,6 +34,8 @@ namespace CommunityBot.Entities
             {
                 _commandHistory.RemoveAt(0); //remove the first element, ensures the list always got 5 elements maximum
             }
+            
+            CommandHistory = new ReadOnlyCollection<CommandInformation>(_commandHistory);
         }
         
         public string TimeZone { get; set; } // Please note, TimeZone ID works for LINUX, but for windows we need TimeZone NAME

--- a/CommunityBot/Extensions/MiunieCommandContext.cs
+++ b/CommunityBot/Extensions/MiunieCommandContext.cs
@@ -12,9 +12,13 @@ namespace CommunityBot.Extensions
         public MiunieCommandContext(DiscordSocketClient client, SocketUserMessage msg) : base(client, msg)
         {
             if (User is null) { return; }
+
             UserAccount = GlobalUserAccounts.GetUserAccount(User);
-            
-            var commandUsedInformation = new CommandInformation(msg.Content, msg.CreatedAt.DateTime);
+        }
+
+        public void RegisterCommandUsage()
+        {
+            var commandUsedInformation = new CommandInformation(Message.Content, Message.CreatedAt.DateTime);
             
             UserAccount.AddCommandToHistory(commandUsedInformation);
 

--- a/CommunityBot/Handlers/CommandHandler.cs
+++ b/CommunityBot/Handlers/CommandHandler.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using CommunityBot.Extensions;
 using Discord.Commands;
 using Discord.WebSocket;
 using CommunityBot.Features.GlobalAccounts;
@@ -32,9 +33,8 @@ namespace CommunityBot.Handlers
         {
             if (!(s is SocketUserMessage msg)) return;
             if (msg.Channel is SocketDMChannel) return;
-
-            var context = new SocketCommandContext(_client, msg);
-            if (context.User.IsBot) return;
+            if (msg.Author.IsBot) return;
+            var context = new MiunieCommandContext(_client, msg);
 
             await RoleByPhraseProvider.EvaluateMessage(
                 context.Guild,
@@ -47,7 +47,9 @@ namespace CommunityBot.Handlers
             {
                 var cmdSearchResult = _cmdService.Search(context, argPos);
                 if (!cmdSearchResult.IsSuccess) return;
-
+                
+                context.RegisterCommandUsage();
+                
                 var executionTask = _cmdService.ExecuteAsync(context, argPos, _serviceProvider);
 
                 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed

--- a/CommunityBot/Modules/Account/ManageUserAccount.cs
+++ b/CommunityBot/Modules/Account/ManageUserAccount.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using CommunityBot.Extensions;
 using CommunityBot.Features.GlobalAccounts;
 using CommunityBot.Helpers;
 using Discord;
@@ -10,7 +11,7 @@ using Discord.WebSocket;
 namespace CommunityBot.Modules.Account
 {
     [Group("account")]
-    public class MangeUserAccount : ModuleBase<SocketCommandContext>
+    public class ManageUserAccount : ModuleBase<MiunieCommandContext>
     {
         [Command("info")]
         public async Task AccountInformation(SocketGuildUser user = null)
@@ -36,6 +37,11 @@ namespace CommunityBot.Modules.Account
             await Context.Channel.SendMessageAsync(Context.User.Mention, false, embed);
         }
 
+        [Command("ShowCommandHistory"), Alias("CommandHistory")]
+        public async Task ShowCommandHistory()
+        {
+            await Context.Channel.SendMessageAsync(String.Join("\n", Context.UserAccount.CommandHistory.Select(cH => $"{cH.UsageDate.ToString("G")} {cH.Command}")));
+        }
         [Command("GetAllMyAccountData"), Alias("GetMyData", "MyData")]
         public async Task GetAccountFile()
         {
@@ -64,6 +70,7 @@ namespace CommunityBot.Modules.Account
             }
         }
 
+        
         private async Task EvaluateResponse(SocketMessage response, string optionYes)
         {
             var message = "";

--- a/CommunityBot/Modules/Admin.cs
+++ b/CommunityBot/Modules/Admin.cs
@@ -6,12 +6,13 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using System.IO;
+using CommunityBot.Extensions;
 using CommunityBot.Handlers;
 using CommunityBot.Preconditions;
 
 namespace CommunityBot.Modules
 {
-    public class Admin : ModuleBase<SocketCommandContext>
+    public class Admin : ModuleBase<MiunieCommandContext>
     {
         private static readonly OverwritePermissions denyOverwrite = new OverwritePermissions(addReactions: PermValue.Deny, sendMessages: PermValue.Deny, attachFiles: PermValue.Deny);
 

--- a/CommunityBot/Modules/Announcements.cs
+++ b/CommunityBot/Modules/Announcements.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
+using CommunityBot.Extensions;
 using CommunityBot.Features.GlobalAccounts;
 using Discord;
 using Discord.Commands;
@@ -8,7 +9,7 @@ namespace CommunityBot.Modules
 {
     [Group("Announcements"), Alias("Announcement"), Summary("Settings for announcements")]
     [RequireUserPermission(GuildPermission.Administrator)]
-    public class Announcement : ModuleBase<SocketCommandContext>
+    public class Announcement : ModuleBase<MiunieCommandContext>
     {
         [Command("SetChannel"), Alias("Set"), RequireUserPermission(GuildPermission.Administrator)]
         [Remarks("Sets the channel where to post announcements")]
@@ -30,7 +31,7 @@ namespace CommunityBot.Modules
     }
     [Group("Welcome")]
     [Summary("DM a joining user a random message out of the ones defined.")]
-    public class WelcomeMessages : ModuleBase<SocketCommandContext>
+    public class WelcomeMessages : ModuleBase<MiunieCommandContext>
     {
         [Command("add"), RequireUserPermission(GuildPermission.Administrator)]
         [Remarks("Example: `welcome add <usermention>, welcome to **<guildname>**! " +
@@ -89,7 +90,7 @@ namespace CommunityBot.Modules
     [Summary("Announce a leaving user in the set announcement channel" +
              "with a random message out of the ones defined.")
     ]
-    public class LeaveMessages : ModuleBase<SocketCommandContext>
+    public class LeaveMessages : ModuleBase<MiunieCommandContext>
     {
         [Command("add"), RequireUserPermission(GuildPermission.Administrator)]
         [Remarks("Example: `leave add Oh noo! <usermention>, left <guildname>...`\n" +

--- a/CommunityBot/Modules/Basics.cs
+++ b/CommunityBot/Modules/Basics.cs
@@ -1,11 +1,12 @@
 ﻿using CommunityBot.Preconditions;
 using Discord.Commands;
 using System.Threading.Tasks;
+using CommunityBot.Extensions;
 using Discord;
 
 namespace CommunityBot.Modules
 {
-    public class Basics : ModuleBase<SocketCommandContext>
+    public class Basics : ModuleBase<MiunieCommandContext>
     {
         [Command("Hello")]
         [Cooldown(5)]

--- a/CommunityBot/Modules/Blogs.cs
+++ b/CommunityBot/Modules/Blogs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using CommunityBot.Configuration;
+using CommunityBot.Extensions;
 using CommunityBot.Features.Blogs;
 using CommunityBot.Handlers;
 using Discord;
@@ -12,7 +13,7 @@ using Newtonsoft.Json;
 namespace CommunityBot.Modules
 {
     [Group("Blog"), Summary("Enables you to create a block that people can subscribe to so they don't miss out if you publish a new one")]
-    public class Blogs : ModuleBase<SocketCommandContext>
+    public class Blogs : ModuleBase<MiunieCommandContext>
     {
         private static readonly string blogFile = "blogs.json";
         [Command("Create"), Remarks("Create a new named block")]

--- a/CommunityBot/Modules/Economy.cs
+++ b/CommunityBot/Modules/Economy.cs
@@ -4,13 +4,14 @@ using Discord;
 using Discord.Commands;
 using System.Linq;
 using System.Threading.Tasks;
+using CommunityBot.Extensions;
 using static CommunityBot.Global;
 using static CommunityBot.Features.Economy.Transfer;
 // ReSharper disable ConvertIfStatementToSwitchStatement
 
 namespace CommunityBot.Modules
 {
-    public class Economy : ModuleBase<SocketCommandContext>
+    public class Economy : ModuleBase<MiunieCommandContext>
     {
         [Command("Daily"), Remarks("Gives you some Miunies but can only be used once a day")]
         [Alias("GetDaily", "ClaimDaily")]

--- a/CommunityBot/Modules/Fun/Trivia.cs
+++ b/CommunityBot/Modules/Fun/Trivia.cs
@@ -1,10 +1,11 @@
 ﻿using System.Threading.Tasks;
+using CommunityBot.Extensions;
 using CommunityBot.Features.Trivia;
 using Discord.Commands;
 
 namespace CommunityBot.Modules.Fun
 {
-    public class Trivia : ModuleBase<SocketCommandContext>
+    public class Trivia : ModuleBase<MiunieCommandContext>
     {
         private readonly TriviaGames _triviaGames;
 

--- a/CommunityBot/Modules/Misc.cs
+++ b/CommunityBot/Modules/Misc.cs
@@ -8,11 +8,12 @@ using System.Threading.Tasks;
 using System.Text;
 using CommunityBot.Helpers;
 using System.Globalization;
+using CommunityBot.Extensions;
 using CommunityBot.Features.Lists;
 
 namespace CommunityBot.Modules
 {
-    public class Misc : ModuleBase<SocketCommandContext>
+    public class Misc : ModuleBase<MiunieCommandContext>
     {
         private CommandService _service;
 

--- a/CommunityBot/Modules/Prefix.cs
+++ b/CommunityBot/Modules/Prefix.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
+using CommunityBot.Extensions;
 using CommunityBot.Features.GlobalAccounts;
 using Discord;
 using Discord.Commands;
@@ -8,7 +9,7 @@ namespace CommunityBot.Modules
 {
     [Group("Prefix"), Alias("Prefixes"), Summary("Setting for the Bots prefix on this server")]
     [RequireContext(ContextType.Guild)]
-    public class Prefix : ModuleBase<SocketCommandContext>
+    public class Prefix : ModuleBase<MiunieCommandContext>
     {
         [Command("add"), Alias("set"), RequireUserPermission(GuildPermission.Administrator)]
         [Remarks("Adds a prefix to the list of prefixes")]

--- a/CommunityBot/Modules/Reminder.cs
+++ b/CommunityBot/Modules/Reminder.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Threading.Tasks;
 using CommunityBot.Entities;
+using CommunityBot.Extensions;
 using CommunityBot.Features.GlobalAccounts;
 using Discord;
 using Discord.Commands;
@@ -42,7 +43,7 @@ namespace CommunityBot.Modules
     /// </summary>
     [Group("Reminder"), Alias("Remind", "r")]
     [Summary("Tell the bot to remind you in some amount of time. The bot will send you a DM with the text you specified.")]
-    public class Reminder : ModuleBase<SocketCommandContext>
+    public class Reminder : ModuleBase<MiunieCommandContext>
     {
         [Command(""), Alias("New", "Add"), Priority(0), Remarks("Add a reminder")]
         public async Task AddReminder([Remainder] string args)

--- a/CommunityBot/Modules/RepeatedTasks.cs
+++ b/CommunityBot/Modules/RepeatedTasks.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CommunityBot.Extensions;
 using Discord;
 using Discord.Commands;
 
@@ -7,7 +8,7 @@ namespace CommunityBot.Modules
 {
     [Group("Tasks"), Remarks("Settings for the repeated task that run in the background")] 
     [Alias("Task", "T")]
-    public class RepeatedTasks : ModuleBase<SocketCommandContext>
+    public class RepeatedTasks : ModuleBase<MiunieCommandContext>
     {
         [Command("")]
         [Alias("List", "L")]

--- a/CommunityBot/Modules/RoleAssignments/RoleByPhrase.cs
+++ b/CommunityBot/Modules/RoleAssignments/RoleByPhrase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using CommunityBot.Extensions;
 using CommunityBot.Features.GlobalAccounts;
 using CommunityBot.Providers;
 using Discord;
@@ -10,7 +11,7 @@ namespace CommunityBot.Modules.RoleAssignments
 {
     [Group("RoleByPhrase"), Alias("rbp"), Summary("Settings for auto-assigning roles based on a sent Phrase")]
     [RequireUserPermission(GuildPermission.Administrator)]
-    public class RoleByPhrase : ModuleBase<SocketCommandContext>
+    public class RoleByPhrase : ModuleBase<MiunieCommandContext>
     {
         [Command("status"), Alias("s"), RequireUserPermission(GuildPermission.Administrator)]
         [Remarks("Returns the current state of RoleByPhrase lists and relations.")]

--- a/CommunityBot/Modules/ServerBots.cs
+++ b/CommunityBot/Modules/ServerBots.cs
@@ -4,13 +4,14 @@ using Discord;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using CommunityBot.Extensions;
 using CommunityBot.Features.GlobalAccounts;
 
 namespace CommunityBot.Modules
 {
     [Group("Bots")]
     [Summary("Allows access to pending and archived invite links to bots. This allows for you to submit your invite links for bots so that the guild's managers can add them.")]
-    public class ServerBots : ModuleBase<SocketCommandContext>
+    public class ServerBots : ModuleBase<MiunieCommandContext>
     {
         [Serializable]
         public class AllGuildsData

--- a/CommunityBot/Modules/ServerSetup.cs
+++ b/CommunityBot/Modules/ServerSetup.cs
@@ -1,11 +1,12 @@
 ﻿using System.Threading.Tasks;
+using CommunityBot.Extensions;
 using CommunityBot.Features.GlobalAccounts;
 using Discord;
 using Discord.Commands;
 
 namespace CommunityBot.Modules
 {
-    public class ServerSetup : ModuleBase<SocketCommandContext>
+    public class ServerSetup : ModuleBase<MiunieCommandContext>
 
     {
 

--- a/CommunityBot/Modules/SetTimeZone.cs
+++ b/CommunityBot/Modules/SetTimeZone.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CommunityBot.Extensions;
 using CommunityBot.Features.GlobalAccounts;
 using Discord.Commands;
 using Newtonsoft.Json;
@@ -6,7 +7,7 @@ using Ofl.Google.Maps.TimeZone;
 
 namespace CommunityBot.Modules
 {
-   public class SetTimeZone : ModuleBase<SocketCommandContext>
+   public class SetTimeZone : ModuleBase<MiunieCommandContext>
     {
         [Command("MyCity")]
         public async Task SetMyCity([Remainder] string city)

--- a/CommunityBot/Modules/Tags.cs
+++ b/CommunityBot/Modules/Tags.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using CommunityBot.Features.GlobalAccounts;
 using Discord;
 using CommunityBot.Entities;
+using CommunityBot.Extensions;
 
 namespace CommunityBot.Modules
 {
@@ -10,7 +11,7 @@ namespace CommunityBot.Modules
     [Summary("Permanently assing a message to a keyword (for this server) which " +
              "the bot will repeat if someone uses this command with that keyword.")]
     [RequireContext(ContextType.Guild)]
-    public class ServerTags : ModuleBase<SocketCommandContext>
+    public class ServerTags : ModuleBase<MiunieCommandContext>
     {
         [Command(""), Priority(-1), Remarks("Let the bot send a message with the content of the named tag on the server")]
         public async Task ShowTag(string tagName)
@@ -63,7 +64,7 @@ namespace CommunityBot.Modules
     [Summary("Permanently assing a message to a keyword (global for you) which " +
              "the bot will repeat if you use this command with that keyword.")]
     [RequireContext(ContextType.Guild)]
-    public class PersonalTags : ModuleBase<SocketCommandContext>
+    public class PersonalTags : ModuleBase<MiunieCommandContext>
     {
         [Command(""), Priority(-1), Remarks("Lets the bot send a message with the content of your named tag")]
         public async Task ShowTag(string tagName = "")

--- a/CommunityBot/Modules/Voice.cs
+++ b/CommunityBot/Modules/Voice.cs
@@ -1,11 +1,12 @@
 ﻿using Discord;
 using Discord.Commands;
 using System.Threading.Tasks;
+using CommunityBot.Extensions;
 using CommunityBot.Preconditions;
 
 namespace CommunityBot.Modules
 {
-    public class Voice : ModuleBase<SocketCommandContext>
+    public class Voice : ModuleBase<MiunieCommandContext>
     {
         const int maxTimeInMinutes = 3600000;
 


### PR DESCRIPTION
## Related issue
#94 

## Changes
- Modified every command module to use `MiunieCommandContext`.
- Created a public property in `GlobalUserAccount`, because it isn't saving the private one. The difference is, the public property is a read only list.
- Added a method to `MiunieCommandContext` to register the command usage. This is to avoid registering invalid commands to the history, or just regular messages, since the command context is created on every message.
- The command handler now checks if the message author is a bot *before* creating the context.
- Renamed `MangeUserAccount.cs` to `ManageUserAccount.cs`, was a typo.
- Added a command to `ManageuserAccount` to display the command history, getting the account from the context.
## Expected feedback
How would you improve it? I kinda dislike `context.RegisterCommandUsage();` https://github.com/discord-bot-tutorial/Community-Discord-BOT/compare/master...Charly6596:master#diff-4c15cfbd9925bf285318bae54c47f9daR51) (not sure how to link to lines) I think it would be better to extend `ModuleBase` and modify the `AfterExecute(CommandInfo command)` method to save better information about the command used. We could also add _Interactive_ methods to the extended `ModuleBase` since some modules uses it.
