### PR TITLE
Change cylinderString to StringBuilder instead of string +=, per #74

### DIFF
--- a/CommunityBot.NUnit.Tests/FeatureTests/SlotsTests.cs
+++ b/CommunityBot.NUnit.Tests/FeatureTests/SlotsTests.cs
@@ -1,0 +1,77 @@
+﻿using CommunityBot.Features.Economy;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CommunityBot.NUnit.Tests.FeatureTests
+{
+    public class SlotsTests
+    {
+        private Slot defaultSlot = new Slot();
+
+        [Test]
+        public void Slots_Constructor_DefaultValue_SlotPiecesEqualsMinSpawnRate()
+        {
+            int totalMinSpawnRate = Slot.PossibleSlotPieces.Sum(p => p.minSpawnCount);
+            Assert.AreEqual(totalMinSpawnRate, defaultSlot.Cylinders.First().SlotPieces.Count());
+        }
+
+        [Test]
+        public void Slots_Constructor_FewerPiecesThanMinSpawnRate_SlotPiecesEqualsMinSpawnRate()
+        {
+            int totalMinSpawnRate = Slot.PossibleSlotPieces.Sum(p => p.minSpawnCount);
+            int numberOfPieces = totalMinSpawnRate - 1;
+            var slot = new Slot(numberOfPieces);
+            Assert.AreEqual(totalMinSpawnRate, defaultSlot.Cylinders.First().SlotPieces.Count());
+        }
+
+        [Test]
+        public void Slots_Constructor_GreaterPiecesThanMinSpawnRate_SlotPiecesEqualsPieceCount()
+        {
+            int totalMinSpawnRate = Slot.PossibleSlotPieces.Sum(p => p.minSpawnCount);
+            int numberOfPieces = totalMinSpawnRate + 1;
+            var slot = new Slot(numberOfPieces);
+            Assert.AreEqual(totalMinSpawnRate, defaultSlot.Cylinders.First().SlotPieces.Count());
+        }
+
+        [Test]
+        public void Slots_GetPayoutAndFlavourText_FlavorTextNotEmptyMoneyGainNotNegativeFor1()
+        {
+            var payoutAndFlavorText = defaultSlot.GetPayoutAndFlavourText(1);
+            Assert.IsNotEmpty(payoutAndFlavorText.Item2);
+            Assert.IsTrue(payoutAndFlavorText.Item1 >= 0);
+        }
+
+        [Test]
+        public void Slots_GetCylinderEmojis_ShowAllFalse_LineCountEqualsDefault3()
+        {
+            List<string> cylinderEmojis = defaultSlot.GetCylinderEmojis();
+            Assert.AreEqual(3, cylinderEmojis.Count);
+        }
+
+        [Test]
+        public void Slots_GetCylinderEmojis_ShowAllFalse_LinesEqualSpinLines()
+        {
+            List<string> spinResultLines = defaultSlot.Spin().Split("\n").ToList();
+            List<string> cylinderEmojis = defaultSlot.GetCylinderEmojis();
+            Assert.AreEqual(spinResultLines.Count, cylinderEmojis.Count);
+            Assert.AreEqual(spinResultLines[0], cylinderEmojis[0]);
+            Assert.AreEqual(spinResultLines[1], cylinderEmojis[1]);
+            Assert.AreEqual(spinResultLines[2], cylinderEmojis[2]);
+        }
+
+        [Test]
+        public void Slots_GetCylinderEmojis_ShowAllTrue_LineCountEqualSlotPieces()
+        {
+            List<string> expected = defaultSlot.GetCylinderEmojis(true);
+            Assert.AreEqual(defaultSlot.Cylinders.First().SlotPieces.Count(), expected.Count);
+        }
+
+        [Test]
+        public void Slots_Spin_ResultNotEmpty()
+        {
+            string spinResult = defaultSlot.Spin();
+            Assert.IsNotEmpty(spinResult);
+        }
+    }
+}

--- a/CommunityBot.NUnit.Tests/FeatureTests/SlotsTests.cs
+++ b/CommunityBot.NUnit.Tests/FeatureTests/SlotsTests.cs
@@ -7,7 +7,7 @@ namespace CommunityBot.NUnit.Tests.FeatureTests
 {
     public class SlotsTests
     {
-        private Slot defaultSlot = new Slot();
+        private readonly Slot defaultSlot = new Slot();
 
         [Test]
         public void Slots_Constructor_DefaultValue_SlotPiecesEqualsMinSpawnRate()
@@ -22,7 +22,7 @@ namespace CommunityBot.NUnit.Tests.FeatureTests
             int totalMinSpawnRate = Slot.PossibleSlotPieces.Sum(p => p.minSpawnCount);
             int numberOfPieces = totalMinSpawnRate - 1;
             var slot = new Slot(numberOfPieces);
-            Assert.AreEqual(totalMinSpawnRate, defaultSlot.Cylinders.First().SlotPieces.Count());
+            Assert.AreEqual(totalMinSpawnRate, slot.Cylinders.First().SlotPieces.Count());
         }
 
         [Test]
@@ -31,7 +31,7 @@ namespace CommunityBot.NUnit.Tests.FeatureTests
             int totalMinSpawnRate = Slot.PossibleSlotPieces.Sum(p => p.minSpawnCount);
             int numberOfPieces = totalMinSpawnRate + 1;
             var slot = new Slot(numberOfPieces);
-            Assert.AreEqual(totalMinSpawnRate, defaultSlot.Cylinders.First().SlotPieces.Count());
+            Assert.AreEqual(numberOfPieces, slot.Cylinders.First().SlotPieces.Count());
         }
 
         [Test]

--- a/CommunityBot.NUnit.Tests/FeatureTests/SlotsTests.cs
+++ b/CommunityBot.NUnit.Tests/FeatureTests/SlotsTests.cs
@@ -7,7 +7,13 @@ namespace CommunityBot.NUnit.Tests.FeatureTests
 {
     public class SlotsTests
     {
-        private readonly Slot defaultSlot = new Slot();
+        private Slot defaultSlot;
+
+        [SetUp]
+        public void TestSetup()
+        {
+            defaultSlot = new Slot();
+        }
 
         [Test]
         public void Slots_Constructor_DefaultValue_SlotPiecesEqualsMinSpawnRate()
@@ -17,7 +23,7 @@ namespace CommunityBot.NUnit.Tests.FeatureTests
         }
 
         [Test]
-        public void Slots_Constructor_FewerPiecesThanMinSpawnRate_SlotPiecesEqualsMinSpawnRate()
+        public static void Slots_Constructor_FewerPiecesThanMinSpawnRate_SlotPiecesEqualsMinSpawnRate()
         {
             int totalMinSpawnRate = Slot.PossibleSlotPieces.Sum(p => p.minSpawnCount);
             int numberOfPieces = totalMinSpawnRate - 1;
@@ -26,7 +32,7 @@ namespace CommunityBot.NUnit.Tests.FeatureTests
         }
 
         [Test]
-        public void Slots_Constructor_GreaterPiecesThanMinSpawnRate_SlotPiecesEqualsPieceCount()
+        public static void Slots_Constructor_GreaterPiecesThanMinSpawnRate_SlotPiecesEqualsPieceCount()
         {
             int totalMinSpawnRate = Slot.PossibleSlotPieces.Sum(p => p.minSpawnCount);
             int numberOfPieces = totalMinSpawnRate + 1;

--- a/CommunityBot/Features/Economy/Slots.cs
+++ b/CommunityBot/Features/Economy/Slots.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace CommunityBot.Features.Economy
 {
@@ -152,14 +153,16 @@ namespace CommunityBot.Features.Economy
             List<string> response = new List<string>();
             int piceCount = Cylinders[0].SlotPieces.Count;
             int loopMax = showAll ? piceCount : 3;
+            StringBuilder cylinderString = new StringBuilder(36); //36=3*":strawberry:".Length
             for (int j = 0; j < loopMax; j++)
             {
-                string cylinderString = "";
                 for (int i = 0; i < 3; i++)
                 {
-                    cylinderString += Cylinders[i].SlotPieces[(Cylinders[i].Pointer + j) % piceCount].emoji;
+                    cylinderString.Append(Cylinders[i].SlotPieces[(Cylinders[i].Pointer + j) % piceCount].emoji);
                 }
-                response.Add(cylinderString);
+
+                response.Add(cylinderString.ToString());
+                cylinderString.Clear();
             }
             return response;
         }

--- a/CommunityBot/Features/Economy/Slots.cs
+++ b/CommunityBot/Features/Economy/Slots.cs
@@ -31,7 +31,9 @@ namespace CommunityBot.Features.Economy
         private static int maxRandom;
 
         // The amount of pieces per cylinder is adjustable but will always be at least the sum of the minSpawnCount of all possible SlotPieces
-        public Slot(int amountOfPieces = 0)
+        public Slot() : this(0) { }
+
+        public Slot(int amountOfPieces)
         {
             maxRandom = 0;
             foreach (var piece in PossibleSlotPieces)

--- a/CommunityBot/Features/Economy/Slots.cs
+++ b/CommunityBot/Features/Economy/Slots.cs
@@ -31,16 +31,16 @@ namespace CommunityBot.Features.Economy
         private static int maxRandom;
 
         // The amount of pieces per cylinder is adjustable but will always be at least the sum of the minSpawnCount of all possible SlotPieces
-        public Slot(int amountOfPices = 0)
+        public Slot(int amountOfPieces = 0)
         {
             maxRandom = 0;
             foreach (var piece in PossibleSlotPieces)
             {
                 maxRandom += piece.spawnrate;
             }
-            Cylinders.Add(new Cylinder(amountOfPices));
-            Cylinders.Add(new Cylinder(amountOfPices));
-            Cylinders.Add(new Cylinder(amountOfPices));
+            Cylinders.Add(new Cylinder(amountOfPieces));
+            Cylinders.Add(new Cylinder(amountOfPieces));
+            Cylinders.Add(new Cylinder(amountOfPieces));
         }
 
         public class Cylinder {
@@ -153,7 +153,8 @@ namespace CommunityBot.Features.Economy
             List<string> response = new List<string>();
             int piceCount = Cylinders[0].SlotPieces.Count;
             int loopMax = showAll ? piceCount : 3;
-            StringBuilder cylinderString = new StringBuilder(36); //36=3*":strawberry:".Length
+            var cylinderString = new StringBuilder(36); //36=3*":strawberry:".Length
+
             for (int j = 0; j < loopMax; j++)
             {
                 for (int i = 0; i < 3; i++)


### PR DESCRIPTION
## Related issue
#74 

## Changes
Changed the cylinderString that is built to use a StringBuilder instead of concatenating, per the flag from the Codacy bot in #74 . 

## Expected feedback
Created a basic unit test that was not included to validate that the method was still functional. Could look at adding unit tests for this class or it could be handled in its own issue.
