### PR TITLE
Implement InMemoryDataStorage and its UnitTests

### DIFF
--- a/CommunityBot.NUnit.Tests/InMemoryStorageTests.cs
+++ b/CommunityBot.NUnit.Tests/InMemoryStorageTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using CommunityBot.Configuration;
+using NUnit.Framework;
+
+namespace CommunityBot.NUnit.Tests
+{
+    public class InMemoryStorageTests
+    {
+        private static readonly string TestStorageKey = "UnitTestKey";
+        private IDataStorage storage;
+
+        [SetUp]
+        public void SetUpTest()
+        {
+            storage = new InMemoryDataStorage();
+        }
+
+        [Test]
+        public void AddingAndRestoringNewItem_Test()
+        {
+            var expected = GetTimeBasedStringWithSuffix("value");
+
+            storage.StoreObject(expected, TestStorageKey);
+            var actual = storage.RestoreObject<string>(TestStorageKey);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void FailingCastingThrows_Test()
+        {
+            storage.StoreObject(GetTimeBasedStringWithSuffix("value"), TestStorageKey);
+            
+            Assert.Throws<InvalidCastException>(() => storage.RestoreObject<int>(TestStorageKey));
+        }
+
+        [Test]
+        public void GettingUnknownKeyThrows_Test()
+        {
+            Assert.Throws<KeyNotFoundException>(() => storage.RestoreObject<string>(TestStorageKey));
+        }
+
+        [Test]
+        public void StoreAndRestoreMultipleObjectOfDifferentTypes_Test()
+        {
+            const string numberKey = "MyNumber";
+            const string characterKey = "MyCharacter";
+            const int expectedNumber = 88;
+            const char expectedCharacter = 'G';
+            storage.StoreObject(expectedNumber, numberKey);
+            storage.StoreObject(expectedCharacter, characterKey);
+
+            var actualNumber = storage.RestoreObject<int>(numberKey);
+            var actualCharacter = storage.RestoreObject<char>(characterKey);
+
+            Assert.AreEqual(expectedNumber, actualNumber);
+            Assert.AreEqual(expectedCharacter, actualCharacter);
+        }
+
+        [Test]
+        public void OverwriteStoredValue_Test()
+        {
+            const string expectedOld = "MyOldValue";
+            const string expectedNew = "MyNewValue";
+            storage.StoreObject(expectedOld, TestStorageKey);
+
+            var actualOld = storage.RestoreObject<string>(TestStorageKey);
+            Assert.AreEqual(expectedOld, actualOld);
+
+            storage.StoreObject(expectedNew, TestStorageKey);
+            var actualNew = storage.RestoreObject<string>(TestStorageKey);
+
+            Assert.AreEqual(expectedNew, actualNew);
+        }
+
+        private static string GetTimeBasedStringWithSuffix(string suffix)
+        {
+            var dateTimeString = DateTime.Now.ToString("HH:mm:ss");
+            return $"{dateTimeString}{suffix}";
+        }
+    }
+}

--- a/CommunityBot/Configuration/InMemoryDataStorage.cs
+++ b/CommunityBot/Configuration/InMemoryDataStorage.cs
@@ -4,7 +4,7 @@ namespace CommunityBot.Configuration
 {
     public class InMemoryDataStorage : IDataStorage
     {
-        Dictionary<string, object> storage;
+        private readonly Dictionary<string, object> storage;
 
         public InMemoryDataStorage()
         {

--- a/CommunityBot/Configuration/InMemoryDataStorage.cs
+++ b/CommunityBot/Configuration/InMemoryDataStorage.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+
+namespace CommunityBot.Configuration
+{
+    public class InMemoryDataStorage : IDataStorage
+    {
+        Dictionary<string, object> storage;
+
+        public InMemoryDataStorage()
+        {
+            storage = new Dictionary<string, object>();
+        }
+
+        public bool KeyExists(string key)
+        {
+            return storage.ContainsKey(key);
+        }
+
+        public T RestoreObject<T>(string key)
+        {
+            // NOTE(Peter): This is not handled as an
+            // exception is assumed to be thrown when
+            // trying to get a non existent type.
+            return (T)storage[key];
+        }
+
+        public void StoreObject(object obj, string key)
+        {
+            if(storage.ContainsKey(key)) 
+            { 
+                storage[key] = obj; 
+            }
+            else
+            {
+                storage.Add(key, obj);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This creates the concretion of IDataStorage to hold data in
memory. This feature is mainly for unit test use as the use
of actual JsonStorage is not practical there.

## Related issue
This fixes #127.

## Changes
* Addition of `InMemoryDataStorage.cs` (implements IDataStorage)
* Addition of `InMemoryStorageTests.cs` (unit tests for the new class)

## Expected feedback
Unit tests are working and the feature will not most likely be used in production (only in Unit tests), so it just would be nice to get another set of eyes looking at the issue in case I made a terrible mistake somewhere. 😅 
