### PR TITLE
Deny transfer cash to bot

### DIFF
--- a/CommunityBot/Features/Economy/Transfer.cs
+++ b/CommunityBot/Features/Economy/Transfer.cs
@@ -5,11 +5,13 @@ namespace CommunityBot.Features.Economy
 {
     internal static class Transfer
     {
-        internal enum TransferResult { Success, SelfTransfer, NotEnoughMiunies }
+        internal enum TransferResult { Success, SelfTransfer, TransferToBot, NotEnoughMiunies }
 
         internal static TransferResult UserToUser(IUser from, IUser to, ulong amount)
         {
             if (from.Id == to.Id) return TransferResult.SelfTransfer;
+            
+            if (to.Id == Global.Client.CurrentUser.Id ) return TransferResult.TransferToBot;
 
             var transferSource = GlobalUserAccounts.GetUserAccount(from.Id);
 

--- a/CommunityBot/Modules/Economy.cs
+++ b/CommunityBot/Modules/Economy.cs
@@ -1,4 +1,5 @@
-﻿using CommunityBot.Features.Economy;
+﻿using System;
+using CommunityBot.Features.Economy;
 using CommunityBot.Features.GlobalAccounts;
 using Discord;
 using Discord.Commands;
@@ -125,18 +126,23 @@ namespace CommunityBot.Modules
             // UserToUser alone doesn't mean much.
             var result = Transfer.UserToUser(Context.User, target, amount);
 
-            if (result == TransferResult.SelfTransfer)
+            switch (result)
             {
-                await ReplyAsync(":negative_squared_cross_mark: You can't gift yourself...\n**And you KNOW it!**");
-            }
-            else if (result == TransferResult.NotEnoughMiunies)
-            {
-                var userAccount = GlobalUserAccounts.GetUserAccount(Context.User.Id);
-                await ReplyAsync($":negative_squared_cross_mark: You don't have that much Minuies! You only have {userAccount.Miunies}.");
-            }
-            else if (result == TransferResult.Success)
-            {
-                await ReplyAsync($":white_check_mark: {Context.User.Username} has given {target.Username} {amount} Minuies!");
+                case TransferResult.SelfTransfer:
+                    await ReplyAsync(":negative_squared_cross_mark: You can't gift yourself...\n**And you KNOW it!**");
+                    break;
+                case TransferResult.TransferToBot:
+                    await ReplyAsync(":negative_squared_cross_mark: Come on! Did you forget who had given it to you?");
+                    break;
+                case TransferResult.NotEnoughMiunies:
+                    var userAccount = GlobalUserAccounts.GetUserAccount(Context.User.Id);
+                    await ReplyAsync($":negative_squared_cross_mark: You don't have that much Minuies! You only have {userAccount.Miunies}.");
+                    break;
+                case TransferResult.Success:
+                    await ReplyAsync($":white_check_mark: {Context.User.Username} has given {target.Username} {amount} Minuies!");
+                    break;
+                default:
+                    throw new InvalidOperationException($"It's definitely not a valid enum const {result}");
             }
         }
 

--- a/CommunityBot/Modules/Economy.cs
+++ b/CommunityBot/Modules/Economy.cs
@@ -126,23 +126,22 @@ namespace CommunityBot.Modules
             // UserToUser alone doesn't mean much.
             var result = Transfer.UserToUser(Context.User, target, amount);
 
-            switch (result)
+            if (result == TransferResult.SelfTransfer)
             {
-                case TransferResult.SelfTransfer:
-                    await ReplyAsync(":negative_squared_cross_mark: You can't gift yourself...\n**And you KNOW it!**");
-                    break;
-                case TransferResult.TransferToBot:
-                    await ReplyAsync(":negative_squared_cross_mark: Come on! Did you forget who had given it to you?");
-                    break;
-                case TransferResult.NotEnoughMiunies:
-                    var userAccount = GlobalUserAccounts.GetUserAccount(Context.User.Id);
-                    await ReplyAsync($":negative_squared_cross_mark: You don't have that much Minuies! You only have {userAccount.Miunies}.");
-                    break;
-                case TransferResult.Success:
-                    await ReplyAsync($":white_check_mark: {Context.User.Username} has given {target.Username} {amount} Minuies!");
-                    break;
-                default:
-                    throw new InvalidOperationException($"It's definitely not a valid enum const {result}");
+                await ReplyAsync(":negative_squared_cross_mark: You can't gift yourself...\n**And you KNOW it!**");
+            }
+            else if (result == TransferResult.TransferToBot)
+            {
+                await ReplyAsync(":negative_squared_cross_mark: Come on! Did you forget who had given it to you?");
+            }
+            else if (result == TransferResult.NotEnoughMiunies)
+            {
+                var userAccount = GlobalUserAccounts.GetUserAccount(Context.User.Id);
+                await ReplyAsync($":negative_squared_cross_mark: You don't have that much Minuies! You only have {userAccount.Miunies}.");
+            }
+            else if (result == TransferResult.Success)
+            {
+                await ReplyAsync($":white_check_mark: {Context.User.Username} has given {target.Username} {amount} Minuies!");
             }
         }
 


### PR DESCRIPTION
## Related issue
Refs #99

## Changes
Tried to reproduce issue with null reference in #99 but did not succeed. `top` command works normally (included bot name in list of course). So I just deny to transfer cash to bot (and show some message instead).