### PR TITLE
Fix restoring of GlobalGuildAccount properties 

### DIFF
--- a/CommunityBot/Entities/GlobalGuildAccount.cs
+++ b/CommunityBot/Entities/GlobalGuildAccount.cs
@@ -17,7 +17,7 @@ namespace CommunityBot.Entities
 
         public ulong AnnouncementChannelId { get; private set; }
 
-        public IReadOnlyList<string> Prefixes { get; private set; } = new List<string>();
+        public IReadOnlyList<string> Prefixes { get; set; } = new List<string>();
 
         public IReadOnlyList<string> WelcomeMessages { get; private set; } = new List<string> { };
 


### PR DESCRIPTION
## Related issue
Stored server prefixes are not restored after restarting the bot #154

## Changes
Setter of the GlobalGuildAccount property `Prefix` is now public to allow it to be restored.
