### PR TITLE
Miunie transfer tests

### DIFF
--- a/CommunityBot.NUnit.Tests/FeatureTests/Economy/TransferTests.cs
+++ b/CommunityBot.NUnit.Tests/FeatureTests/Economy/TransferTests.cs
@@ -9,12 +9,12 @@ using NUnit.Framework;
 
 namespace CommunityBot.NUnit.Tests.FeatureTests.Economy
 {
-    public class TransferTests
+    public static class TransferTests
     {
         // NOTE(Peter): These tests should probably be refactored.
 
         [Test]
-        public void TransferToSameUserThrows()
+        public static void TransferToSameUserThrows()
         {
             const ulong userId = 999777111;
             var globalUserAccountProviderMock = new Mock<IGlobalUserAccountProvider>();
@@ -27,7 +27,7 @@ namespace CommunityBot.NUnit.Tests.FeatureTests.Economy
         }
 
         [Test]
-        public void TransferToThisBotThrows()
+        public static void TransferToThisBotThrows()
         {
             const ulong userId = 555987;
             const ulong thisBotId = 123;
@@ -41,7 +41,7 @@ namespace CommunityBot.NUnit.Tests.FeatureTests.Economy
         }
 
         [Test]
-        public void TransferMiuniesUserDoesNotHaveThrows()
+        public static void TransferMiuniesUserDoesNotHaveThrows()
         {
             const ulong userId = 3358;
             const ulong targetUserId = 9000;
@@ -59,7 +59,7 @@ namespace CommunityBot.NUnit.Tests.FeatureTests.Economy
         }
 
         [Test]
-        public void TransferMiuniesValidTransferFunctions()
+        public static void TransferMiuniesValidTransferFunctions()
         {
             const ulong userId = 6658;
             const ulong targetUserId = 7785;

--- a/CommunityBot.NUnit.Tests/FeatureTests/Economy/TransferTests.cs
+++ b/CommunityBot.NUnit.Tests/FeatureTests/Economy/TransferTests.cs
@@ -1,0 +1,109 @@
+using System;
+using CommunityBot.DiscordAbstractions;
+using CommunityBot.Entities;
+using CommunityBot.Features.Economy;
+using CommunityBot.Features.GlobalAccounts;
+using Discord;
+using Moq;
+using NUnit.Framework;
+
+namespace CommunityBot.NUnit.Tests.FeatureTests.Economy
+{
+    public class TransferTests
+    {
+        // NOTE(Peter): These tests should probably be refactored.
+
+        [Test]
+        public void TransferToSameUserThrows()
+        {
+            const ulong userId = 999777111;
+            var globalUserAccountProviderMock = new Mock<IGlobalUserAccountProvider>();
+            var discordClientMock = new Mock<IDiscordSocketClient>();
+            var miuniesTransfer = new Transfer(globalUserAccountProviderMock.Object, discordClientMock.Object);
+
+            var exception = Assert.Throws<InvalidOperationException>(() => 
+                miuniesTransfer.UserToUser(userId, userId, 50));
+            Assert.AreEqual(Constants.ExTransferSameUser, exception.Message);
+        }
+
+        [Test]
+        public void TransferToThisBotThrows()
+        {
+            const ulong userId = 555987;
+            const ulong thisBotId = 123;
+            var discordClientMock = GetDiscordSocketClientWithSelfUser(thisBotId);
+            var globalUserAccountProviderMock = new Mock<IGlobalUserAccountProvider>();
+            var miuniesTransfer = new Transfer(globalUserAccountProviderMock.Object, discordClientMock.Object);
+
+            var exception = Assert.Throws<InvalidOperationException>(() => 
+                miuniesTransfer.UserToUser(userId, thisBotId, 50));
+            Assert.AreEqual(Constants.ExTransferToMiunie, exception.Message);
+        }
+
+        [Test]
+        public void TransferMiuniesUserDoesNotHaveThrows()
+        {
+            const ulong userId = 3358;
+            const ulong targetUserId = 9000;
+            const ulong maxMiunies = 500;
+            var discordClientMock = GetDiscordSocketClientWithSelfUser(100);
+            var globalUserAccountProviderMock = new Mock<IGlobalUserAccountProvider>();
+            globalUserAccountProviderMock
+                .Setup(m => m.GetById(userId))
+                .Returns(new GlobalUserAccount(userId) {Miunies = maxMiunies});
+            var miuniesTransfer = new Transfer(globalUserAccountProviderMock.Object, discordClientMock.Object);
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                miuniesTransfer.UserToUser(userId, targetUserId, maxMiunies + 10));
+            Assert.AreEqual(Constants.ExTransferNotEnoughFunds, exception.Message);
+        }
+
+        [Test]
+        public void TransferMiuniesValidTransferFunctions()
+        {
+            const ulong userId = 6658;
+            const ulong targetUserId = 7785;
+            const ulong sourceMiunies = 500;
+            const ulong targetMiunies = 255;
+            const ulong transferAmount = 100;
+            var sourceUser = new GlobalUserAccount(userId)
+            {
+                Miunies = sourceMiunies
+            };
+            var targetUser = new GlobalUserAccount(targetUserId)
+            {
+                Miunies = targetMiunies
+            };
+            var discordClientMock = GetDiscordSocketClientWithSelfUser(2);
+            var globalUserAccountProviderMock = new Mock<IGlobalUserAccountProvider>();
+            globalUserAccountProviderMock
+                .Setup(m => m.GetById(userId))
+                .Returns(sourceUser);
+            globalUserAccountProviderMock
+                .Setup(m => m.GetById(targetUserId))
+                .Returns(targetUser);
+            var miuniesTransfer = new Transfer(globalUserAccountProviderMock.Object, discordClientMock.Object);
+
+            miuniesTransfer.UserToUser(userId, targetUserId, transferAmount);
+            
+            Assert.AreEqual(sourceMiunies - transferAmount, sourceUser.Miunies);
+            Assert.AreEqual(targetMiunies + transferAmount, targetUser.Miunies);
+            globalUserAccountProviderMock.Verify(m => m.SaveByIds(userId, targetUserId), Times.Once);
+        }
+
+        private static Mock<ISelfUser> GetSelfUserMock(ulong id)
+        {
+            var thisBotMock = new Mock<ISelfUser>();
+            thisBotMock.Setup(m => m.Id).Returns(id);
+            return thisBotMock;
+        }
+
+        private static Mock<IDiscordSocketClient> GetDiscordSocketClientWithSelfUser(ulong id)
+        {
+            var self = GetSelfUserMock(id);
+            var discordClientMock = new Mock<IDiscordSocketClient>();
+            discordClientMock.Setup(m => m.GetCurrentUser()).Returns(self.Object);
+            return discordClientMock;
+        }
+    }
+}

--- a/CommunityBot/Constants.cs
+++ b/CommunityBot/Constants.cs
@@ -29,5 +29,8 @@ namespace CommunityBot
 
         // Exception messages
         public static readonly string ExDailyTooSoon = "Cannot give daily sooner than 24 hours after the last one.";
+        public static readonly string ExTransferSameUser = "Cannot transfer miunies to the same user.";
+        public static readonly string ExTransferToMiunie = "Cannot transfer miunies to Miunie.";
+        public static readonly string ExTransferNotEnoughFunds = "Cannot transfer miunies, not enough funds.";
     }
 }

--- a/CommunityBot/DiscordAbstractions/DiscordSocketClientAbstraction.cs
+++ b/CommunityBot/DiscordAbstractions/DiscordSocketClientAbstraction.cs
@@ -1,0 +1,17 @@
+﻿using Discord;
+using Discord.WebSocket;
+
+namespace CommunityBot.DiscordAbstractions
+{
+    public class DiscordSocketClientAbstraction : IDiscordSocketClient
+    {
+        private readonly DiscordSocketClient discordSocketClient;
+
+        public DiscordSocketClientAbstraction(DiscordSocketClient discordSocketClient)
+        {
+            this.discordSocketClient = discordSocketClient;
+        }
+
+        public ISelfUser GetCurrentUser() => discordSocketClient.CurrentUser;
+    }
+}

--- a/CommunityBot/DiscordAbstractions/IDiscordSocketClient.cs
+++ b/CommunityBot/DiscordAbstractions/IDiscordSocketClient.cs
@@ -1,0 +1,9 @@
+using Discord;
+
+namespace CommunityBot.DiscordAbstractions
+{
+    public interface IDiscordSocketClient
+    {
+        ISelfUser GetCurrentUser();
+    }
+}

--- a/CommunityBot/Features/Economy/ITransfer.cs
+++ b/CommunityBot/Features/Economy/ITransfer.cs
@@ -1,0 +1,7 @@
+namespace CommunityBot.Features.Economy
+{
+    public interface IMiuniesTransfer
+    {
+        void UserToUser(ulong sourceUserId, ulong targetUserId, ulong amount);
+    }
+}

--- a/CommunityBot/InversionOfControl.cs
+++ b/CommunityBot/InversionOfControl.cs
@@ -1,4 +1,5 @@
 using CommunityBot.Configuration;
+using CommunityBot.DiscordAbstractions;
 using CommunityBot.Features.Trivia;
 using CommunityBot.Handlers;
 using CommunityBot.Features.Lists;
@@ -52,7 +53,9 @@ namespace CommunityBot
                 c.ForSingletonOf<IOnboarding>().UseIfNone<Onboarding>();
                 c.ForSingletonOf<Features.Onboarding.Tasks.HelloWorldTask>().UseIfNone<Features.Onboarding.Tasks.HelloWorldTask>();
                 c.ForSingletonOf<IGlobalUserAccountProvider>().UseIfNone<GlobalUserAccountProvider>();
+                c.ForSingletonOf<IDiscordSocketClient>().UseIfNone<DiscordSocketClientAbstraction>();
                 c.ForSingletonOf<IDailyMiunies>().UseIfNone<Daily>();
+                c.ForSingletonOf<IMiuniesTransfer>().UseIfNone<Transfer>();
             });
         }
     }


### PR DESCRIPTION
## Related issue
Increasing Unit Test Coverage

## Changes
Cover the Economy > Transfer feature.

## Expected feedback
The Unit Tests are quite open to refactoring, due to the heavy Mocking that is going on in there, it is a bit hard to read.

The hard dependency on DiscordSocketClient has been removed and an Interface IDiscordSocketClient created with a DiscordSocketClientAbstraction implementing that new interface.
This has been done to allow mocking of the socket client. We should work towards replacing every hard dependency of DiscordSocketClient with this new interface (by also expanding what the interface covers)
