### PR TITLE
Fix for AwaitMessage and EvaluateResponse

### DIFF
--- a/CommunityBot/Helpers/DiscordExtensions.cs
+++ b/CommunityBot/Helpers/DiscordExtensions.cs
@@ -72,13 +72,17 @@ namespace CommunityBot.Helpers
             // Waiting for the timeout to run out or the task.Delay to be canceled due to a matched message
             try { await waiter; }
             catch (TaskCanceledException) { }
-            // Remove the function from the 
-            Global.Client.MessageReceived -= OnMessageReceived;
+            finally
+            {
+                // Remove the function from the event handler list
+                Global.Client.MessageReceived -= OnMessageReceived;
+            }
             return responseMessage;
 
             Task OnMessageReceived(SocketMessage message)
             {
-                if (message.Channel != channel)
+                // look for a response on the same channel, and ignore messages from any bots (which includes itself)
+                if (message.Channel.Id != channel.Id || message.Author.IsBot)
                     return Task.CompletedTask;
                 if (filter != null && !filter(message))
                     return Task.CompletedTask;

--- a/CommunityBot/Modules/Account/ManageUserAccount.cs
+++ b/CommunityBot/Modules/Account/ManageUserAccount.cs
@@ -109,6 +109,6 @@ namespace CommunityBot.Modules.Account
         }
 
         private bool EvaluateResponse(SocketMessage arg, params String[] options)
-            => options.Any(option => arg.Content.ToLower().Contains(option.ToLower()) && arg.Author == Context.User);
+            => options.Any(option => arg.Content.ToLower().Contains(option.ToLower()) && arg.Author.Id == Context.User.Id);
     }
 }


### PR DESCRIPTION
## Related issue
This pull request fixes #168

## Changes
In DiscordExtensions.AwaitMessage:
- The channel comparison is based on the Id field of the channel
- Messages from bots are ignored
- The code to remove the local handler from the handler list is moved into a finally block
In ManageUserAccount.EvaluateResponse:
- The user comparison is based on the Id field of the user
